### PR TITLE
fix: No internal retries and reduce timeout

### DIFF
--- a/Runtime/Scripts/Core/Request/WebRequestInternal.cs
+++ b/Runtime/Scripts/Core/Request/WebRequestInternal.cs
@@ -16,8 +16,8 @@ namespace JoystickRemoteConfig.Core.Web
         public event Action<WebRequestResponseData> OnRequestDone;
         public event Action<int> OnRequestWillRestart;
 
-        private const int RequestTimeOut = 8;
-        private int _requestAttemptsLimit = 3;
+        private const int RequestTimeOut = 4;
+        private int _requestAttemptsLimit = 1;
 
         public WebRequestState RequestState { get; private set; }
         


### PR DESCRIPTION
No retries allows us to handle errors ourselves instead of potentially blocking for ~36s without knowing what's happening.
Also reduces the timeout to 4s as we'd rather retry in the background instead of blocking on initial load